### PR TITLE
Checkstyle, DRY UuidModule's assignUuid()

### DIFF
--- a/src/main/java/com/graphaware/module/uuid/UuidModule.java
+++ b/src/main/java/com/graphaware/module/uuid/UuidModule.java
@@ -15,6 +15,10 @@
  */
 package com.graphaware.module.uuid;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
 import com.graphaware.common.util.Change;
 import com.graphaware.common.uuid.EaioUuidGenerator;
 import com.graphaware.common.uuid.UuidGenerator;
@@ -24,12 +28,8 @@ import com.graphaware.runtime.module.BaseTxDrivenModule;
 import com.graphaware.runtime.module.DeliberateTransactionRollbackException;
 import com.graphaware.tx.event.improved.api.ImprovedTransactionData;
 import com.graphaware.tx.executor.batch.IterableInputBatchTransactionExecutor;
-import com.graphaware.tx.executor.batch.UnitOfWork;
 import com.graphaware.tx.executor.input.AllNodes;
 import com.graphaware.tx.executor.input.AllRelationships;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
 
 /**
  * {@link com.graphaware.runtime.module.TxDrivenModule} that assigns UUID's to nodes in the graph.

--- a/src/main/java/com/graphaware/module/uuid/index/LegacyIndexer.java
+++ b/src/main/java/com/graphaware/module/uuid/index/LegacyIndexer.java
@@ -19,6 +19,7 @@ package com.graphaware.module.uuid.index;
 import com.graphaware.module.uuid.UuidConfiguration;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 
 /**
@@ -34,6 +35,18 @@ public class LegacyIndexer implements UuidIndexer {
         this.configuration = configuration;
     }
 
+    /**
+     * @inheritDoc
+     */
+    @Override
+	public void index(PropertyContainer propertyContainer) {		
+    	if (propertyContainer instanceof Node) {
+    		indexNode( (Node) propertyContainer);
+    	} else {
+    		indexRelationship( (Relationship) propertyContainer);
+    	}    	
+	}
+    
     /**
      * @inheritDoc
      */
@@ -81,4 +94,5 @@ public class LegacyIndexer implements UuidIndexer {
     public Relationship getRelationshipByUuid(String uuid) {
         return database.index().forRelationships(configuration.getUuidRelationshipIndex()).get(configuration.getUuidProperty(), uuid).getSingle();
     }
+
 }

--- a/src/main/java/com/graphaware/module/uuid/index/UuidIndexer.java
+++ b/src/main/java/com/graphaware/module/uuid/index/UuidIndexer.java
@@ -17,6 +17,7 @@
 package com.graphaware.module.uuid.index;
 
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 
 /**
@@ -24,6 +25,13 @@ import org.neo4j.graphdb.Relationship;
  */
 public interface UuidIndexer {
 
+	/**
+     * Index a node based on the UUID property
+     *
+     * @param node the node to index
+     */
+    void index(PropertyContainer propertyContainer);
+    
     /**
      * Index a node based on the UUID property
      *

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
@@ -15,23 +15,34 @@
  */
 package com.graphaware.module.uuid;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.Iterators.asIterable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
 import com.graphaware.common.policy.BaseNodeInclusionPolicy;
 import com.graphaware.common.policy.BaseRelationshipInclusionPolicy;
 import com.graphaware.common.util.IterableUtils;
 import com.graphaware.module.uuid.read.DefaultUuidReader;
-import com.graphaware.module.uuid.read.UuidReader;
 import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.neo4j.graphdb.*;
-import org.neo4j.test.TestGraphDatabaseFactory;
-
-import static org.junit.Assert.*;
-import static org.neo4j.helpers.collection.Iterators.asIterable;
 
 
 public class UuidModuleEmbeddedProgrammaticTest {

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleMultipleModulesTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleMultipleModulesTest.java
@@ -84,12 +84,9 @@ public class UuidModuleMultipleModulesTest extends GraphAwareIntegrationTest {
         //Retrieve
         assertEquals("{\"results\":[{\"columns\":[\"id(n)\"],\"data\":[{\"row\":[1],\"meta\":[null]}]}],\"errors\":[]}", findNodeByUuid("UID2", uuid));
     }
-
-    private String findNodeByUuid(String uuid) {
-        return httpClient.executeCypher(baseNeoUrl(), "CALL ga.uuid.findNode('" + uuid + "') YIELD node as n return id(n)");
-    }
-
+    
     private String findNodeByUuid(String moduleId, String uuid) {
         return httpClient.executeCypher(baseNeoUrl(), "CALL ga.uuid.nd.findNode('" + moduleId + "','" + uuid + "') YIELD node as n return id(n)");
     }
+
 }

--- a/src/test/java/ga/uuid/NodeUuidProcedureTest.java
+++ b/src/test/java/ga/uuid/NodeUuidProcedureTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
 public class NodeUuidProcedureTest extends ProcedureIntegrationTest {
 
     @Override
-    protected Class procedureClass() {
+    protected Class<NodeUuidProcedure> procedureClass() {
         return NodeUuidProcedure.class;
     }
 
@@ -51,7 +51,8 @@ public class NodeUuidProcedureTest extends ProcedureIntegrationTest {
             Result result = getDatabase().execute("CALL ga.uuid.findNodes({uuids}) YIELD nodes RETURN nodes", params);
             while (result.hasNext()) {
                 Map<String, Object> row = result.next();
-                List<Node> nodes = (List<Node>) row.get("nodes");
+                @SuppressWarnings("unchecked")
+				List<Node> nodes = (List<Node>) row.get("nodes");
                 assertEquals(2, nodes.size());
                 assertEquals(aleId, nodes.get(0).getId(), 0L);
                 assertEquals(luanneId, nodes.get(1).getId(), 0L);

--- a/src/test/java/ga/uuid/ProcedureIntegrationTest.java
+++ b/src/test/java/ga/uuid/ProcedureIntegrationTest.java
@@ -19,7 +19,7 @@ abstract class ProcedureIntegrationTest extends EmbeddedDatabaseIntegrationTest 
         return "neo4j-uuid-all.conf";
     }
 
-    protected abstract Class procedureClass();
+    protected abstract Class<? extends UuidProcedure> procedureClass();
 
     protected void emptyDb() {
         try (Transaction tx = getDatabase().beginTx()) {

--- a/src/test/java/ga/uuid/RelationshipUuidProcedureTest.java
+++ b/src/test/java/ga/uuid/RelationshipUuidProcedureTest.java
@@ -1,22 +1,22 @@
 package ga.uuid;
 
-import org.junit.Test;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.Transaction;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 
 public class RelationshipUuidProcedureTest extends ProcedureIntegrationTest {
 
     @Override
-    protected Class procedureClass() {
+    protected Class<RelationshipUuidProcedure> procedureClass() {
         return RelationshipUuidProcedure.class;
     }
 
@@ -55,7 +55,8 @@ public class RelationshipUuidProcedureTest extends ProcedureIntegrationTest {
             while (result.hasNext()) {
                 ++i;
                 Map<String, Object> row = result.next();
-                List<Relationship> rels = (List<Relationship>) row.get("relationships");
+                @SuppressWarnings("unchecked")
+				List<Relationship> rels = (List<Relationship>) row.get("relationships");
                 assertEquals(2, rels.size());
                 assertEquals(relId1, rels.get(0).getId(), 0L);
                 assertEquals(relId2, rels.get(1).getId(), 0L);


### PR DESCRIPTION
I've recently done some work with Neo4j modules and the GraphAware Framework. Because the UUID module is useful and serves as an excellent example and case study for getting familiar with modules, I thought I would share what I think are some (trivial) improvements.

This pull request resolves some Checkstyle warnings (cleaning of unused imports, removal of some unused code, the suppression of a few unchecked conversions by adding @SupressWarnings, etc) and includes a bit of refactoring to DRY/consolidate the assignUuid() within the UuidModule. I tend to prefer working with PropertyContainers rather than explicitly having separate methods/code that work with Nodes and Relationships individually. This is largely a matter of personal style obviously, so please apply these changes as you see fit.