### PR TITLE
Specifying the Generator Through Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Please refer to Javadoc for more detail.
 ### Specifying the Generator Through Configuration
 
 By default, the `com.graphaware.common.uuid.EaioUuidGenerator` is used to generate the underlying UUID. Any generator implementation can be used, be it 
-out of the box or your own custom code, by modifying the `conf/neo4j.conf`. The following example configures the UUID module to make use of the JavaUtilUUIDGenerator:
+out of the box or your own custom code, by modifying the `conf/neo4j.conf`. The following example configures the UUID module to make use of the `JavaUtilUUIDGenerator`:
 
 ```
 com.graphaware.runtime.enabled=true
@@ -179,7 +179,7 @@ com.graphaware.module.UUID.relationship=com.graphaware.runtime.policy.all.Includ
 com.graphaware.module.UUID.uuidGeneratorClass=com.graphaware.module.uuid.generator.JavaUtilUUIDGenerator
 ```
 
-The following example configures the UUID module to make use of the SequenceIdGenerator:
+The following example configures the UUID module to make use of the `SequenceIdGenerator`:
 
 ```
 com.graphaware.runtime.enabled=true

--- a/README.md
+++ b/README.md
@@ -166,6 +166,34 @@ To use the Java API to find a node by its UUID, please instantiate `UuidReader` 
 
 Please refer to Javadoc for more detail.
 
+### Specifying the Generator Through Configuration
+
+By default, the `com.graphaware.common.uuid.EaioUuidGenerator` is used to generate the underlying UUID. Any generator implementation can be used, be it 
+out of the box or your own custom code, by modifying the `conf/neo4j.conf`. The following example configures the UUID module to make use of the JavaUtilUUIDGenerator:
+
+```
+com.graphaware.runtime.enabled=true
+
+com.graphaware.module.UUID.1=com.graphaware.module.uuid.UuidBootstrapper
+com.graphaware.module.UUID.relationship=com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships
+com.graphaware.module.UUID.uuidGeneratorClass=com.graphaware.module.uuid.generator.JavaUtilUUIDGenerator
+```
+
+The following example configures the UUID module to make use of the SequenceIdGenerator:
+
+```
+com.graphaware.runtime.enabled=true
+
+com.graphaware.module.UUID.1=com.graphaware.module.uuid.UuidBootstrapper
+com.graphaware.module.UUID.relationship=com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships
+com.graphaware.module.UUID.uuidProperty=sequence
+com.graphaware.module.UUID.uuidGeneratorClass=com.graphaware.module.uuid.generator.SequenceIdGenerator
+```
+
+Please see the `com.graphaware.common.uuid.UuidGenerator` interface and the `com.graphaware.module.uuid.generator` package for more information 
+and examples of how to implement your own generator. 
+
+
 License
 -------
 

--- a/src/main/java/com/graphaware/module/GraphDatabaseServiceAware.java
+++ b/src/main/java/com/graphaware/module/GraphDatabaseServiceAware.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.graphaware.module;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+/**
+ * Interface to be implemented by any object that wishes to be provided with a GraphDatabaseService.
+ */
+public interface GraphDatabaseServiceAware {
+
+	public void setGraphDatabaseService(GraphDatabaseService database);
+	
+}

--- a/src/main/java/com/graphaware/module/uuid/GraphDatabaseServiceAware.java
+++ b/src/main/java/com/graphaware/module/uuid/GraphDatabaseServiceAware.java
@@ -13,7 +13,7 @@
  * the GNU General Public License along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package com.graphaware.module;
+package com.graphaware.module.uuid;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 

--- a/src/main/java/com/graphaware/module/uuid/UuidBootstrapper.java
+++ b/src/main/java/com/graphaware/module/uuid/UuidBootstrapper.java
@@ -22,6 +22,8 @@ import com.graphaware.common.log.LoggerFactory;
 import com.graphaware.runtime.module.BaseRuntimeModuleBootstrapper;
 import com.graphaware.runtime.module.RuntimeModule;
 import com.graphaware.runtime.module.RuntimeModuleBootstrapper;
+
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 
@@ -36,6 +38,7 @@ public class UuidBootstrapper extends BaseRuntimeModuleBootstrapper<UuidConfigur
     private static final String UUID_INDEX = "uuidIndex";
     private static final String UUID_RELATIONSHIP_INDEX = "uuidRelationshipIndex";
     private static final String STRIP_HYPHENS = "stripHyphens";
+    private static final String UUID_GENERATOR_CLASS = "uuidGeneratorClass";
 
     /**
      * {@inheritDoc}
@@ -50,26 +53,38 @@ public class UuidBootstrapper extends BaseRuntimeModuleBootstrapper<UuidConfigur
      */
     @Override
     protected RuntimeModule doBootstrapModule(String moduleId, Map<String, String> config, GraphDatabaseService database, UuidConfiguration configuration) {
-        if (config.get(UUID_PROPERTY) != null && config.get(UUID_PROPERTY).length() > 0) {
-            configuration = configuration.withUuidProperty(config.get(UUID_PROPERTY));
+    	
+    	String uuidProperty = config.get(UUID_PROPERTY);
+        if (StringUtils.isNotBlank(uuidProperty)) {
+            configuration = configuration.withUuidProperty(uuidProperty);
             LOG.info("uuidProperty set to %s", configuration.getUuidProperty());
         }
 
-        if (config.get(UUID_INDEX) != null && config.get(UUID_INDEX).length() > 0) {
-            configuration = configuration.withUuidIndex(config.get(UUID_INDEX));
+        String uuidIndex = config.get(UUID_INDEX);
+        if (StringUtils.isNotBlank(uuidIndex)) {
+            configuration = configuration.withUuidIndex(uuidIndex);
             LOG.info("uuidIndex set to %s", configuration.getUuidIndex());
         }
 
-        if (config.get(UUID_RELATIONSHIP_INDEX) != null && config.get(UUID_RELATIONSHIP_INDEX).length() > 0) {
-            configuration = configuration.withUuidRelationshipIndex(config.get(UUID_RELATIONSHIP_INDEX));
+        String uuidRelationshipIndex = config.get(UUID_RELATIONSHIP_INDEX);
+        if (StringUtils.isNotBlank(uuidRelationshipIndex)) {
+            configuration = configuration.withUuidRelationshipIndex(uuidRelationshipIndex);
             LOG.info("uuidRelationshipIndex set to %s", configuration.getUuidRelationshipIndex());
         }
 
-        if (config.get(STRIP_HYPHENS) != null && config.get(STRIP_HYPHENS).length() > 0) {
-            boolean stripHyphens = Boolean.valueOf(config.get(STRIP_HYPHENS));
+        String stripHypensString = config.get(STRIP_HYPHENS);        
+        if (StringUtils.isNotBlank(stripHypensString)) {
+            boolean stripHyphens = Boolean.valueOf(stripHypensString);
             configuration = configuration.withStripHyphensProperty(stripHyphens);
             LOG.info("stripHyphens set to %s", configuration.shouldStripHyphens());
         }
+        
+        String uuidGeneratorClassString = config.get(UUID_GENERATOR_CLASS);
+        if (StringUtils.isNotBlank(uuidGeneratorClassString)) {
+            configuration = configuration.withUuidGenerator(uuidGeneratorClassString);
+            LOG.info("uuidGenerator set to %s", configuration.getUuidGenerator());
+        }
+        
 
         return new UuidModule(moduleId, configuration, database);
     }

--- a/src/main/java/com/graphaware/module/uuid/UuidConfiguration.java
+++ b/src/main/java/com/graphaware/module/uuid/UuidConfiguration.java
@@ -26,18 +26,22 @@ import com.graphaware.runtime.policy.InclusionPoliciesFactory;
  */
 public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfiguration> {
 
+	private static final String DEFAULT_UUID_GENERATOR = "com.graphaware.common.uuid.EaioUuidGenerator";
+	
     private static final String DEFAULT_UUID_PROPERTY = Properties.UUID;
     private static final String DEFAULT_UUID_NODEX_INDEX = Indexes.UUID_NODE_INDEX;
     private static final String DEFAULT_UUID_REL_INDEX = Indexes.UUID_REL_INDEX;
     private static final boolean DEFAULT_STRIP_HYPHENS = false;
 
+    private final String uuidGenerator;
     private final String uuidProperty;
     private final String uuidIndex;
     private final String uuidRelationshipIndex;
     private final Boolean stripHyphens;
 
-    private UuidConfiguration(InclusionPolicies inclusionPolicies, long initializeUntil, String uuidProperty, boolean stripHyphens, String uuidIndex, String uuidRelationshipIndex) {
+    private UuidConfiguration(InclusionPolicies inclusionPolicies, long initializeUntil, String uuidGenerator, String uuidProperty, boolean stripHyphens, String uuidIndex, String uuidRelationshipIndex) {
         super(inclusionPolicies, initializeUntil);
+        this.uuidGenerator = uuidGenerator;
         this.uuidProperty = uuidProperty;
         this.uuidIndex = uuidIndex;
         this.uuidRelationshipIndex = uuidRelationshipIndex;
@@ -57,7 +61,7 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
         return new UuidConfiguration(InclusionPoliciesFactory
                 .allBusiness()
                 .with(IncludeNoRelationships.getInstance())
-                , ALWAYS, DEFAULT_UUID_PROPERTY, DEFAULT_STRIP_HYPHENS, DEFAULT_UUID_NODEX_INDEX, DEFAULT_UUID_REL_INDEX);
+                , ALWAYS, DEFAULT_UUID_GENERATOR, DEFAULT_UUID_PROPERTY, DEFAULT_STRIP_HYPHENS, DEFAULT_UUID_NODEX_INDEX, DEFAULT_UUID_REL_INDEX);
     }
 
     /**
@@ -65,10 +69,14 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
      */
     @Override
     protected UuidConfiguration newInstance(InclusionPolicies inclusionPolicies, long initializeUntil) {
-        return new UuidConfiguration(inclusionPolicies, initializeUntil, getUuidProperty(), shouldStripHyphens(), getUuidIndex(), getUuidRelationshipIndex());
+        return new UuidConfiguration(inclusionPolicies, initializeUntil, getUuidGenerator(), getUuidProperty(), shouldStripHyphens(), getUuidIndex(), getUuidRelationshipIndex());
     }
 
-    public String getUuidProperty() {
+    public String getUuidGenerator() {
+		return uuidGenerator;
+	}
+
+	public String getUuidProperty() {
         return uuidProperty;
     }
 
@@ -85,13 +93,23 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
     }
 
     /**
+     * Create a new instance of this {@link UuidConfiguration} with different uuid generator.
+     *
+     * @param uuidProperty of the new instance.
+     * @return new instance.
+     */
+    public UuidConfiguration withUuidGenerator(String uuidGenerator) {
+    	return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), uuidGenerator, getUuidProperty(), shouldStripHyphens(), getUuidIndex(), getUuidRelationshipIndex());
+    }
+    
+    /**
      * Create a new instance of this {@link UuidConfiguration} with different uuid property.
      *
      * @param uuidProperty of the new instance.
      * @return new instance.
      */
     public UuidConfiguration withUuidProperty(String uuidProperty) {
-        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), uuidProperty, shouldStripHyphens(), getUuidIndex(), getUuidRelationshipIndex());
+        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidGenerator(), uuidProperty, shouldStripHyphens(), getUuidIndex(), getUuidRelationshipIndex());
     }
 
     /**
@@ -101,7 +119,7 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
      * @return new instance.
      */
     public UuidConfiguration withUuidIndex(String uuidIndex) {
-        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidProperty(), shouldStripHyphens(), uuidIndex, getUuidRelationshipIndex());
+        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidGenerator(), getUuidProperty(), shouldStripHyphens(), uuidIndex, getUuidRelationshipIndex());
     }
 
     /**
@@ -111,7 +129,7 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
      * @return new instance.
      */
     public UuidConfiguration withUuidRelationshipIndex(String uuidRelationshipIndex) {
-        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidProperty(), shouldStripHyphens(), getUuidIndex(), uuidRelationshipIndex);
+        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidGenerator(), getUuidProperty(), shouldStripHyphens(), getUuidIndex(), uuidRelationshipIndex);
     }
 
     /**
@@ -121,7 +139,7 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
      * @return new instance.
      */
     public UuidConfiguration withStripHyphensProperty(boolean stripHyphens) {
-        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidProperty(), stripHyphens, getUuidIndex(), getUuidRelationshipIndex());
+        return new UuidConfiguration(getInclusionPolicies(), initializeUntil(), getUuidGenerator(), getUuidProperty(), stripHyphens, getUuidIndex(), getUuidRelationshipIndex());
     }
 
     /**
@@ -165,6 +183,7 @@ public class UuidConfiguration extends BaseTxDrivenModuleConfiguration<UuidConfi
     @Override
     public int hashCode() {
         int result = super.hashCode();
+        result = 31 * result + uuidGenerator.hashCode();
         result = 31 * result + uuidProperty.hashCode();
         result = 31 * result + uuidIndex.hashCode();
         result = 31 * result + uuidRelationshipIndex.hashCode();

--- a/src/main/java/com/graphaware/module/uuid/UuidModule.java
+++ b/src/main/java/com/graphaware/module/uuid/UuidModule.java
@@ -81,8 +81,12 @@ public class UuidModule extends BaseTxDrivenModule<Void> {
     	}
     	
     }
-    
-    /**
+
+    public UuidGenerator getUuidGenerator() {
+		return uuidGenerator;
+	}
+
+	/**
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/com/graphaware/module/uuid/UuidModule.java
+++ b/src/main/java/com/graphaware/module/uuid/UuidModule.java
@@ -25,7 +25,6 @@ import org.springframework.util.ClassUtils;
 
 import com.graphaware.common.util.Change;
 import com.graphaware.common.uuid.UuidGenerator;
-import com.graphaware.module.GraphDatabaseServiceAware;
 import com.graphaware.module.uuid.index.LegacyIndexer;
 import com.graphaware.module.uuid.index.UuidIndexer;
 import com.graphaware.runtime.module.BaseTxDrivenModule;

--- a/src/main/java/com/graphaware/module/uuid/generator/JavaUtilUUIDGenerator.java
+++ b/src/main/java/com/graphaware/module/uuid/generator/JavaUtilUUIDGenerator.java
@@ -1,0 +1,18 @@
+package com.graphaware.module.uuid.generator;
+
+import java.util.UUID;
+
+import com.graphaware.common.uuid.UuidGenerator;
+
+/**
+ * A simple UuidGenerator implementation that makes use of java.util.UUID to generate UUID's.
+ */
+public class JavaUtilUUIDGenerator implements UuidGenerator {
+
+	@Override
+	public String generateUuid() {
+		UUID uuid = UUID.randomUUID();
+		return uuid.toString();
+	}
+	
+}

--- a/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
+++ b/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
@@ -1,5 +1,8 @@
 package com.graphaware.module.uuid.generator;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 
@@ -7,19 +10,23 @@ import com.graphaware.common.uuid.UuidGenerator;
 import com.graphaware.module.uuid.GraphDatabaseServiceAware;
 
 /**
- * A complex implementation of UuidGenerator that makes use of the provided GraphDatabaseService to 
- * generate a numerically increasing sequence through Cypher.
+ * A non-trivial UuidGenerator implementation that makes use of the provided GraphDatabaseService and 
+ * Cypher to generate a numerically increasing sequence.
  */
 public class SequenceIdGenerator implements UuidGenerator, GraphDatabaseServiceAware {
 
-	public static final String cypher = "MERGE (sequenceMetadata:SequenceMetadata) set sequenceMetadata.sequence = coalesce(sequenceMetadata.sequence, 0) + 1 return sequenceMetadata.sequence";
+	public static final String cypher = "MERGE (sequenceMetadata:SequenceMetadata) set sequenceMetadata.sequence = coalesce(sequenceMetadata.sequence, {initialSequennceValue}) + {sequenceIncrementAmount} return sequenceMetadata.sequence";
 	
 	protected GraphDatabaseService database;
 	
 	@Override
 	public String generateUuid() {
 		
-		Result result = database.execute(cypher);
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("initialSequennceValue", 0);
+		parameters.put("sequenceIncrementAmount", 1);
+		
+		Result result = database.execute(cypher, parameters);
 		
 		long sequence = (long) result.next().values().iterator().next();
 		return String.valueOf(sequence);

--- a/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
+++ b/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
@@ -1,41 +1,106 @@
 package com.graphaware.module.uuid.generator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
 
 import com.graphaware.common.uuid.UuidGenerator;
 import com.graphaware.module.uuid.GraphDatabaseServiceAware;
 
 /**
- * A non-trivial UuidGenerator implementation that makes use of the provided GraphDatabaseService and 
- * Cypher to generate a numerically increasing sequence.
+ * An UuidGenerator implementation that makes use of the provided GraphDatabaseService to generate a numerical id sequence.
  */
 public class SequenceIdGenerator implements UuidGenerator, GraphDatabaseServiceAware {
 
-	public static final String cypher = "MERGE (sequenceMetadata:SequenceMetadata) set sequenceMetadata.sequence = coalesce(sequenceMetadata.sequence, {initialSequennceValue}) + {sequenceIncrementAmount} return sequenceMetadata.sequence";
-	
 	protected GraphDatabaseService database;
+	
+	protected long initialSequenceValue = 0;
+	protected String label = "SequenceMetadata";	
+	protected String sequencePropertyKey = "sequence";
 	
 	@Override
 	public String generateUuid() {
+
+		String result = null;		
+		Label sequenceMetadataLabel = Label.label(label);
+
+		try (Transaction tx = database.beginTx()) {
+
+			Node sequenceMetadataNode = null;
+			ResourceIterator<Node> sequenceMetadataNodes = database.findNodes(sequenceMetadataLabel);
+			
+			int count = 0;
+			while (sequenceMetadataNodes.hasNext()) {
+				sequenceMetadataNode = sequenceMetadataNodes.next();
+				count++;
+			}
+			
+			if (count == 0) {				
+				sequenceMetadataNode = database.createNode(sequenceMetadataLabel);
+				sequenceMetadataNode.setProperty(sequencePropertyKey, initialSequenceValue);
+			} else if (count > 1) {
+				throw new TransactionFailureException("More than one SequenceMetadata node was found, this undoubtedly is a critical issue with the state of the database"); 
+			}
+
+			// Acquiring the write lock is critical to ensure thread safety
+			tx.acquireWriteLock(sequenceMetadataNode);
+			
+			Number sequenceNumber = (Number) sequenceMetadataNode.getProperty(sequencePropertyKey);
+			long currentSequence = sequenceNumber.longValue();			
+			long nextSequence = updateSequence(currentSequence);
+			sequenceMetadataNode.setProperty(sequencePropertyKey, nextSequence);
+
+            result = String.valueOf(nextSequence);
+            
+            tx.success();
+            
+        }
 		
-		Map<String, Object> parameters = new HashMap<String, Object>();
-		parameters.put("initialSequennceValue", 0);
-		parameters.put("sequenceIncrementAmount", 1);
+		return result;
 		
-		Result result = database.execute(cypher, parameters);
-		
-		long sequence = (long) result.next().values().iterator().next();
-		return String.valueOf(sequence);
-		
+	}
+	
+	/**
+	 * Increment the value of the sequence. 
+	 * This is performed in a dedicated method to make it easy to override, should the incrementing algorithm need to be customized.  
+	 * 
+	 * @param currentSequence The current sequence value in the database.
+	 * @return The updated sequence value to be insert into the database.
+	 */
+	protected long updateSequence(long currentSequence) {
+		return currentSequence + 1;
 	}
 
 	@Override
 	public void setGraphDatabaseService(GraphDatabaseService database) {
 		this.database = database;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public long getInitialSequenceValue() {
+		return initialSequenceValue;
+	}
+
+	public void setInitialSequenceValue(long initialSequenceValue) {
+		this.initialSequenceValue = initialSequenceValue;
+	}
+
+	public String getSequencePropertyKey() {
+		return sequencePropertyKey;
+	}
+
+	public void setSequencePropertyKey(String sequencePropertyKey) {
+		this.sequencePropertyKey = sequencePropertyKey;
 	}
 	
 }

--- a/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
+++ b/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
@@ -1,0 +1,34 @@
+package com.graphaware.module.uuid.generator;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+
+import com.graphaware.common.uuid.UuidGenerator;
+import com.graphaware.module.GraphDatabaseServiceAware;
+
+/**
+ * A complex implementation of UuidGenerator that makes use of the provided GraphDatabaseService to 
+ * generate a numerically increasing sequence through Cypher.
+ */
+public class SequenceIdGenerator implements UuidGenerator, GraphDatabaseServiceAware {
+
+	public static final String cypher = "MERGE (sequenceMetadata:SequenceMetadata) set sequenceMetadata.sequence = coalesce(sequenceMetadata.sequence, 0) + 1 return sequenceMetadata.sequence";
+	
+	protected GraphDatabaseService database;
+	
+	@Override
+	public String generateUuid() {
+		
+		Result result = database.execute(cypher);
+		
+		long sequence = (long) result.next().values().iterator().next();
+		return String.valueOf(sequence);
+		
+	}
+
+	@Override
+	public void setGraphDatabaseService(GraphDatabaseService database) {
+		this.database = database;
+	}
+	
+}

--- a/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
+++ b/src/main/java/com/graphaware/module/uuid/generator/SequenceIdGenerator.java
@@ -4,7 +4,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 
 import com.graphaware.common.uuid.UuidGenerator;
-import com.graphaware.module.GraphDatabaseServiceAware;
+import com.graphaware.module.uuid.GraphDatabaseServiceAware;
 
 /**
  * A complex implementation of UuidGenerator that makes use of the provided GraphDatabaseService to 

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleDeclarativeIntegrationTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleDeclarativeIntegrationTest.java
@@ -198,6 +198,17 @@ public class UuidModuleDeclarativeIntegrationTest {
         }
     }
     
+    @Test(expected = NotFoundException.class)
+    public void testUuidGeneratorInvalidGenerator()  {
+        database = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .loadPropertiesFromFile(this.getClass().getClassLoader().getResource("neo4j-uuid-generator-invalid.conf").getPath())
+                .newGraphDatabase();
+
+        // This should cause the expected exception due to an invalid generator being configured
+        getRuntime(database).getModule(UuidModule.class);
+        
+    }
+    
     @Test
     public void testUuidNotAssigned() throws InterruptedException {
         database = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleDeclarativeIntegrationTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleDeclarativeIntegrationTest.java
@@ -20,12 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.helpers.collection.Iterators.*;
+import static org.neo4j.helpers.collection.Iterators.asIterable;
 
-import com.graphaware.module.uuid.api.UuidApi;
-import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
-import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -36,6 +34,14 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.test.TestGraphDatabaseFactory;
+
+import com.graphaware.common.uuid.EaioUuidGenerator;
+import com.graphaware.common.uuid.UuidGenerator;
+import com.graphaware.module.uuid.api.UuidApi;
+import com.graphaware.module.uuid.generator.JavaUtilUUIDGenerator;
+import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
+import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
+
 
 public class UuidModuleDeclarativeIntegrationTest {
 
@@ -109,6 +115,53 @@ public class UuidModuleDeclarativeIntegrationTest {
         }
     }
 
+    @Test
+    public void testDefaultGenerator() {
+        database = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .loadPropertiesFromFile(this.getClass().getClassLoader().getResource("neo4j-uuid.conf").getPath())
+                .newGraphDatabase();
+
+        // Verify the generator instantiated is as expected (the default)
+        UuidModule uuidModule = getRuntime(database).getModule(UuidModule.class);
+        UuidGenerator uuidGenerator = uuidModule.getUuidGenerator();
+        Assert.assertEquals(EaioUuidGenerator.class, uuidGenerator.getClass());
+
+    }
+    
+    @Test
+    public void testUuidGeneratorJavaUtilUUID() throws InterruptedException {
+        database = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .loadPropertiesFromFile(this.getClass().getClassLoader().getResource("neo4j-uuid-generator-java-util.conf").getPath())
+                .newGraphDatabase();
+
+        // Verify the generator instantiated is as expected
+        UuidModule uuidModule = getRuntime(database).getModule(UuidModule.class);
+        UuidGenerator uuidGenerator = uuidModule.getUuidGenerator();
+        Assert.assertEquals(JavaUtilUUIDGenerator.class, uuidGenerator.getClass());
+        
+        getRuntime(database).waitUntilStarted();
+        
+        UuidApi api = new UuidApi(database);
+        //When
+        try (Transaction tx = database.beginTx()) {
+            Node node = database.createNode();
+            node.addLabel(personLabel);
+            node.setProperty("name", "aNode");
+            tx.success();
+        }
+
+        //Then
+        //Retrieve the node and check that it has a uuid property
+        try (Transaction tx = database.beginTx()) {
+            for (Node node : asIterable(database.findNodes(personLabel))) {
+                assertTrue(node.hasProperty(UUID));
+                assertFalse(node.getProperty(UUID).toString().contains("-"));
+                assertEquals(Long.valueOf(node.getId()), api.getNodeIdByUuid((String) node.getProperty(UUID)));
+            }
+            tx.success();
+        }
+    }
+    
     @Test
     public void testUuidNotAssigned() throws InterruptedException {
         database = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
@@ -155,7 +155,7 @@ public class UuidModuleEmbeddedProgrammaticTest {
     public void newNodesWithLabelShouldBeAssignedUuidSequence() {
     	
         //Given
-    	registerModuleWithSequenceGenerator(); //erics
+    	registerModuleWithSequenceGenerator();
 
         //When
         try (Transaction tx = database.beginTx()) {

--- a/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/uuid/UuidModuleEmbeddedProgrammaticTest.java
@@ -21,6 +21,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.Iterators.asIterable;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +39,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -43,6 +52,7 @@ import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
+
 
 
 public class UuidModuleEmbeddedProgrammaticTest {
@@ -1483,5 +1493,65 @@ public class UuidModuleEmbeddedProgrammaticTest {
 
     }
 
+	@Test
+    public void testSequenceGeneratorInMultithreadedEnv() throws Exception {
+		
+        registerModuleWithSequenceGenerator();
 
+        // TODO: Put this into the server extension initialize
+        // TODO: Prevent this node from being deleted
+        try (Transaction tx = database.beginTx()) {
+        	
+        	Node sequenceMetadataNode = database.createNode(Label.label("SequenceMetadata"));
+        	sequenceMetadataNode.setProperty("sequence", 100);
+        	
+        	tx.success();
+        	
+        }
+                
+        final Runnable runner = () -> {
+            try (final Transaction tx = database.beginTx()) {
+                database.createNode(Label.label("SequenceTest"));
+                tx.success();
+            }
+        };
+
+        final ExecutorService service = Executors.newCachedThreadPool();
+        List<Future> futures = new ArrayList<>();
+        IntStream.range(0, 100).forEach(i -> {
+            futures.add(service.submit(runner));
+        });
+
+        try {
+            for (Future future : futures) {
+                future.get();
+            }
+        } catch (Throwable ignore) {}
+
+        service.shutdown();
+
+        Thread.sleep(1000);
+
+        List<String> uuids = new ArrayList<String>();
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("MATCH (n:SequenceTest) RETURN n.sequence AS uuid");
+            while (result.hasNext()) {
+                String uuid = String.valueOf(result.next().get("uuid"));
+                System.out.println("UUID: " + uuid);                
+                assertFalse(uuids.contains(uuid));
+                uuids.add(uuid);
+                	
+            }
+            tx.success();
+        }
+
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("MATCH (n:SequenceMetadata) RETURN count(n) AS c");
+            long count = ((Number) result.next().get("c")).longValue();
+            System.out.println("SequenceMetadata count: " + count);
+            assertEquals(1, count);
+        }
+        
+    }
+    
 }

--- a/src/test/resources/neo4j-uuid-generator-invalid.conf
+++ b/src/test/resources/neo4j-uuid-generator-invalid.conf
@@ -1,0 +1,241 @@
+################################################################
+# GraphAware configuration
+################################################################
+
+dbms.unmanaged_extension_classes=com.graphaware.server=/graphaware
+
+com.graphaware.runtime.enabled=true
+com.graphaware.module.UIDM.1=com.graphaware.module.uuid.UuidBootstrapper
+com.graphaware.module.UIDM.uuidProperty=uuid
+com.graphaware.module.UIDM.uuidIndex=nodeIndex
+com.graphaware.module.UIDM.uuidRelationshipIndex=relIndex
+com.graphaware.module.UIDM.relationship=com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships
+com.graphaware.module.UIDM.stripHyphens=true
+com.graphaware.module.UIDM.uuidGeneratorClass=com.graphaware.module.uuid.generator.NonExistantGenerator
+
+#*****************************************************************
+# Neo4j configuration
+#*****************************************************************
+
+# The name of the database to mount
+#dbms.active_database=graph.db
+
+# Paths of directories in the installation.
+#dbms.directories.data=data
+#dbms.directories.plugins=plugins
+#dbms.directories.certificates=certificates
+
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
+
+# Whether requests to Neo4j are authenticated.
+# To disable authentication, uncomment this line
+dbms.security.auth_enabled=false
+
+# Enable this to be able to upgrade a store from an older version.
+#dbms.allow_format_migration=true
+
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 50% of RAM minus the max Java heap size.
+#dbms.memory.pagecache.size=10g
+
+# Enable online backups to be taken from this database.
+dbms.backup.enabled=false
+
+# To allow remote backups, uncomment this line:
+#dbms.backup.address=0.0.0.0:6362
+
+#*****************************************************************
+# Network connector configuration
+#*****************************************************************
+
+# Bolt connector
+dbms.connector.bolt.type=BOLT
+dbms.connector.bolt.enabled=true
+dbms.connector.bolt.tls_level=OPTIONAL
+# To have Bolt accept non-local connections, uncomment this line
+# dbms.connector.bolt.address=0.0.0.0:7687
+
+# HTTP Connector
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+#dbms.connector.http.encryption=NONE
+# To have HTTP accept non-local connections, uncomment this line
+#dbms.connector.http.address=0.0.0.0:7474
+
+# HTTPS Connector
+dbms.connector.https.type=HTTP
+dbms.connector.https.enabled=true
+dbms.connector.https.encryption=TLS
+dbms.connector.https.address=localhost:7573
+
+# Number of Neo4j worker threads.
+#dbms.threads.worker_count=
+
+#*****************************************************************
+# Logging configuration
+#*****************************************************************
+
+# To enable HTTP logging, uncomment this line
+#dbms.logs.http.enabled=true
+
+# To enable GC Logging, uncomment this line
+#dbms.logs.gc.enabled=true
+
+# GC Logging Options
+# see http://docs.oracle.com/cd/E19957-01/819-0084-10/pt_tuningjava.html#wp57013 for more information.
+#dbms.logs.gc.options=-XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution
+
+# Number of GC logs to keep.
+#dbms.logs.gc.rotation.keep_number=5
+
+# Size of each GC log that is kept.
+#dbms.logs.gc.rotation.size=20m
+
+# Size threshold for rotation of the debug log. If set to zero then no rotation will occur. Accepts a binary suffix "k",
+# "m" or "g".
+#dbms.logs.debug.rotation.size=20m
+
+# Maximum number of history files for the internal log.
+#dbms.logs.debug.rotation.keep_number=7
+
+# Log executed queries that takes longer than the configured threshold. Enable by uncommenting this line.
+#dbms.logs.query.enabled=true
+
+# If the execution of query takes more time than this threshold, the query is logged. If set to zero then all queries
+# are logged.
+#dbms.logs.query.threshold=0
+
+# The file size in bytes at which the query log will auto-rotate. If set to zero then no rotation will occur. Accepts a
+# binary suffix "k", "m" or "g".
+#dbms.logs.query.rotation.size=20m
+
+# Maximum number of history files for the query log.
+#dbms.logs.query.rotation.keep_number=7
+
+#*****************************************************************
+# HA configuration
+#*****************************************************************
+
+# Uncomment and specify these lines for running Neo4j in High Availability mode.
+# See the High availability setup tutorial for more details on these settings
+# http://neo4j.com/docs/3.0.1/ha-setup-tutorial.html
+
+# Database mode
+# Allowed values:
+# HA - High Availability
+# SINGLE - Single mode, default.
+# To run in High Availability mode uncomment this line:
+#dbms.mode=HA
+
+# ha.server_id is the number of each instance in the HA cluster. It should be
+# an integer (e.g. 1), and should be unique for each cluster instance.
+#ha.server_id=
+
+# ha.initial_hosts is a comma-separated list (without spaces) of the host:port
+# where the ha.host.coordination of all instances will be listening. Typically
+# this will be the same for all cluster instances.
+#ha.initial_hosts=127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
+
+# IP and port for this instance to listen on, for communicating cluster status
+# information iwth other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.coordination=127.0.0.1:5001
+
+# IP and port for this instance to listen on, for communicating transaction
+# data with other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.data=127.0.0.1:6001
+
+# The interval at which slaves will pull updates from the master. Comment out
+# the option to disable periodic pulling of updates. Unit is seconds.
+ha.pull_interval=10
+
+# Amount of slaves the master will try to push a transaction to upon commit
+# (default is 1). The master will optimistically continue and not fail the
+# transaction even if it fails to reach the push factor. Setting this to 0 will
+# increase write performance when writing through master but could potentially
+# lead to branched data (or loss of transaction) if the master goes down.
+#ha.tx_push_factor=1
+
+# Strategy the master will use when pushing data to slaves (if the push factor
+# is greater than 0). There are three options available "fixed_ascending" (default),
+# "fixed_descending" or "round_robin". Fixed strategies will start by pushing to
+# slaves ordered by server id (accordingly with qualifier) and are useful when
+# planning for a stable fail-over based on ids.
+#ha.tx_push_strategy=fixed_ascending
+
+# Policy for how to handle branched data.
+#ha.branched_data_policy=keep_all
+
+# How often heartbeat messages should be sent. Defaults to ha.default_timeout.
+#ha.heartbeat_interval=5s
+
+# Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval.
+#ha.heartbeat_timeout=11s
+
+# If you are using a load-balancer that doesn't support HTTP Auth, you may need to turn off authentication for the
+# HA HTTP status endpoint by uncommenting the following line.
+#dbms.security.ha_status_auth_enabled=false
+
+# Whether this instance should only participate as slave in cluster. If set to
+# true, it will never be elected as master.
+#ha.slave_only=false
+
+#*****************************************************************
+# Miscellaneous configuration
+#*****************************************************************
+
+# Enable this to specify a parser other than the default one.
+#cypher.default_language_version=3.0
+
+# Determines if Cypher will allow using file URLs when loading data using
+# `LOAD CSV`. Setting this value to `false` will cause Neo4j to fail `LOAD CSV`
+# clauses that load data from the file system.
+#dbms.security.allow_csv_import_from_file_urls=true
+
+# Retention policy for transaction logs needed to perform recovery and backups.
+#dbms.tx_log.rotation.retention_policy=7 days
+
+# Limit the number of IOs the background checkpoint process will consume per second.
+# This setting is advisory, is ignored in Neo4j Community Edition, and is followed to
+# best effort in Enterprise Edition.
+# An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in
+# this way will leave more bandwidth in the IO subsystem to service random-read IOs,
+# which is important for the response time of queries when the database cannot fit
+# entirely in memory. The only drawback of this setting is that longer checkpoint times
+# may lead to slightly longer recovery times in case of a database or system crash.
+# A lower number means lower IO pressure, and consequently longer checkpoint times.
+# The configuration can also be commented out to remove the limitation entirely, and
+# let the checkpointer flush data as fast as the hardware will go.
+# Set this to -1 to disable the IOPS limit.
+# dbms.checkpoint.iops.limit=1000
+
+# Enable a remote shell server which Neo4j Shell clients can log in to.
+#dbms.shell.enabled=true
+# The network interface IP the shell will listen on (use 0.0.0.0 for all interfaces).
+#dbms.shell.host=127.0.0.1
+# The port the shell will listen on, default is 1337.
+#dbms.shell.port=1337
+
+# Only allow read operations from this Neo4j instance. This mode still requires
+# write access to the directory for lock purposes.
+#dbms.read_only=false
+
+# Comma separated list of JAX-RS packages containing JAX-RS resources, one
+# package name for each mountpoint. The listed package names will be loaded
+# under the mountpoints specified. Uncomment this line to mount the
+# org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
+# neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
+# http://localhost:7474/examples/unmanaged/helloworld/{nodeId}
+#dbms.unmanaged_extension_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
+
+

--- a/src/test/resources/neo4j-uuid-generator-java-util.conf
+++ b/src/test/resources/neo4j-uuid-generator-java-util.conf
@@ -1,0 +1,241 @@
+################################################################
+# GraphAware configuration
+################################################################
+
+dbms.unmanaged_extension_classes=com.graphaware.server=/graphaware
+
+com.graphaware.runtime.enabled=true
+com.graphaware.module.UIDM.1=com.graphaware.module.uuid.UuidBootstrapper
+com.graphaware.module.UIDM.uuidProperty=uuid
+com.graphaware.module.UIDM.uuidIndex=nodeIndex
+com.graphaware.module.UIDM.uuidRelationshipIndex=relIndex
+com.graphaware.module.UIDM.relationship=com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships
+com.graphaware.module.UIDM.stripHyphens=true
+com.graphaware.module.UIDM.uuidGeneratorClass=com.graphaware.module.uuid.generator.JavaUtilUUIDGenerator
+
+#*****************************************************************
+# Neo4j configuration
+#*****************************************************************
+
+# The name of the database to mount
+#dbms.active_database=graph.db
+
+# Paths of directories in the installation.
+#dbms.directories.data=data
+#dbms.directories.plugins=plugins
+#dbms.directories.certificates=certificates
+
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
+
+# Whether requests to Neo4j are authenticated.
+# To disable authentication, uncomment this line
+dbms.security.auth_enabled=false
+
+# Enable this to be able to upgrade a store from an older version.
+#dbms.allow_format_migration=true
+
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 50% of RAM minus the max Java heap size.
+#dbms.memory.pagecache.size=10g
+
+# Enable online backups to be taken from this database.
+dbms.backup.enabled=false
+
+# To allow remote backups, uncomment this line:
+#dbms.backup.address=0.0.0.0:6362
+
+#*****************************************************************
+# Network connector configuration
+#*****************************************************************
+
+# Bolt connector
+dbms.connector.bolt.type=BOLT
+dbms.connector.bolt.enabled=true
+dbms.connector.bolt.tls_level=OPTIONAL
+# To have Bolt accept non-local connections, uncomment this line
+# dbms.connector.bolt.address=0.0.0.0:7687
+
+# HTTP Connector
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+#dbms.connector.http.encryption=NONE
+# To have HTTP accept non-local connections, uncomment this line
+#dbms.connector.http.address=0.0.0.0:7474
+
+# HTTPS Connector
+dbms.connector.https.type=HTTP
+dbms.connector.https.enabled=true
+dbms.connector.https.encryption=TLS
+dbms.connector.https.address=localhost:7573
+
+# Number of Neo4j worker threads.
+#dbms.threads.worker_count=
+
+#*****************************************************************
+# Logging configuration
+#*****************************************************************
+
+# To enable HTTP logging, uncomment this line
+#dbms.logs.http.enabled=true
+
+# To enable GC Logging, uncomment this line
+#dbms.logs.gc.enabled=true
+
+# GC Logging Options
+# see http://docs.oracle.com/cd/E19957-01/819-0084-10/pt_tuningjava.html#wp57013 for more information.
+#dbms.logs.gc.options=-XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution
+
+# Number of GC logs to keep.
+#dbms.logs.gc.rotation.keep_number=5
+
+# Size of each GC log that is kept.
+#dbms.logs.gc.rotation.size=20m
+
+# Size threshold for rotation of the debug log. If set to zero then no rotation will occur. Accepts a binary suffix "k",
+# "m" or "g".
+#dbms.logs.debug.rotation.size=20m
+
+# Maximum number of history files for the internal log.
+#dbms.logs.debug.rotation.keep_number=7
+
+# Log executed queries that takes longer than the configured threshold. Enable by uncommenting this line.
+#dbms.logs.query.enabled=true
+
+# If the execution of query takes more time than this threshold, the query is logged. If set to zero then all queries
+# are logged.
+#dbms.logs.query.threshold=0
+
+# The file size in bytes at which the query log will auto-rotate. If set to zero then no rotation will occur. Accepts a
+# binary suffix "k", "m" or "g".
+#dbms.logs.query.rotation.size=20m
+
+# Maximum number of history files for the query log.
+#dbms.logs.query.rotation.keep_number=7
+
+#*****************************************************************
+# HA configuration
+#*****************************************************************
+
+# Uncomment and specify these lines for running Neo4j in High Availability mode.
+# See the High availability setup tutorial for more details on these settings
+# http://neo4j.com/docs/3.0.1/ha-setup-tutorial.html
+
+# Database mode
+# Allowed values:
+# HA - High Availability
+# SINGLE - Single mode, default.
+# To run in High Availability mode uncomment this line:
+#dbms.mode=HA
+
+# ha.server_id is the number of each instance in the HA cluster. It should be
+# an integer (e.g. 1), and should be unique for each cluster instance.
+#ha.server_id=
+
+# ha.initial_hosts is a comma-separated list (without spaces) of the host:port
+# where the ha.host.coordination of all instances will be listening. Typically
+# this will be the same for all cluster instances.
+#ha.initial_hosts=127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
+
+# IP and port for this instance to listen on, for communicating cluster status
+# information iwth other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.coordination=127.0.0.1:5001
+
+# IP and port for this instance to listen on, for communicating transaction
+# data with other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.data=127.0.0.1:6001
+
+# The interval at which slaves will pull updates from the master. Comment out
+# the option to disable periodic pulling of updates. Unit is seconds.
+ha.pull_interval=10
+
+# Amount of slaves the master will try to push a transaction to upon commit
+# (default is 1). The master will optimistically continue and not fail the
+# transaction even if it fails to reach the push factor. Setting this to 0 will
+# increase write performance when writing through master but could potentially
+# lead to branched data (or loss of transaction) if the master goes down.
+#ha.tx_push_factor=1
+
+# Strategy the master will use when pushing data to slaves (if the push factor
+# is greater than 0). There are three options available "fixed_ascending" (default),
+# "fixed_descending" or "round_robin". Fixed strategies will start by pushing to
+# slaves ordered by server id (accordingly with qualifier) and are useful when
+# planning for a stable fail-over based on ids.
+#ha.tx_push_strategy=fixed_ascending
+
+# Policy for how to handle branched data.
+#ha.branched_data_policy=keep_all
+
+# How often heartbeat messages should be sent. Defaults to ha.default_timeout.
+#ha.heartbeat_interval=5s
+
+# Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval.
+#ha.heartbeat_timeout=11s
+
+# If you are using a load-balancer that doesn't support HTTP Auth, you may need to turn off authentication for the
+# HA HTTP status endpoint by uncommenting the following line.
+#dbms.security.ha_status_auth_enabled=false
+
+# Whether this instance should only participate as slave in cluster. If set to
+# true, it will never be elected as master.
+#ha.slave_only=false
+
+#*****************************************************************
+# Miscellaneous configuration
+#*****************************************************************
+
+# Enable this to specify a parser other than the default one.
+#cypher.default_language_version=3.0
+
+# Determines if Cypher will allow using file URLs when loading data using
+# `LOAD CSV`. Setting this value to `false` will cause Neo4j to fail `LOAD CSV`
+# clauses that load data from the file system.
+#dbms.security.allow_csv_import_from_file_urls=true
+
+# Retention policy for transaction logs needed to perform recovery and backups.
+#dbms.tx_log.rotation.retention_policy=7 days
+
+# Limit the number of IOs the background checkpoint process will consume per second.
+# This setting is advisory, is ignored in Neo4j Community Edition, and is followed to
+# best effort in Enterprise Edition.
+# An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in
+# this way will leave more bandwidth in the IO subsystem to service random-read IOs,
+# which is important for the response time of queries when the database cannot fit
+# entirely in memory. The only drawback of this setting is that longer checkpoint times
+# may lead to slightly longer recovery times in case of a database or system crash.
+# A lower number means lower IO pressure, and consequently longer checkpoint times.
+# The configuration can also be commented out to remove the limitation entirely, and
+# let the checkpointer flush data as fast as the hardware will go.
+# Set this to -1 to disable the IOPS limit.
+# dbms.checkpoint.iops.limit=1000
+
+# Enable a remote shell server which Neo4j Shell clients can log in to.
+#dbms.shell.enabled=true
+# The network interface IP the shell will listen on (use 0.0.0.0 for all interfaces).
+#dbms.shell.host=127.0.0.1
+# The port the shell will listen on, default is 1337.
+#dbms.shell.port=1337
+
+# Only allow read operations from this Neo4j instance. This mode still requires
+# write access to the directory for lock purposes.
+#dbms.read_only=false
+
+# Comma separated list of JAX-RS packages containing JAX-RS resources, one
+# package name for each mountpoint. The listed package names will be loaded
+# under the mountpoints specified. Uncomment this line to mount the
+# org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
+# neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
+# http://localhost:7474/examples/unmanaged/helloworld/{nodeId}
+#dbms.unmanaged_extension_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
+
+

--- a/src/test/resources/neo4j-uuid-generator-sequenceid.conf
+++ b/src/test/resources/neo4j-uuid-generator-sequenceid.conf
@@ -1,0 +1,242 @@
+################################################################
+# GraphAware configuration
+################################################################
+
+dbms.unmanaged_extension_classes=com.graphaware.server=/graphaware
+
+com.graphaware.runtime.enabled=true
+com.graphaware.module.UIDM.1=com.graphaware.module.uuid.UuidBootstrapper
+com.graphaware.module.UIDM.uuidProperty=uuid
+com.graphaware.module.UIDM.uuidIndex=nodeIndex
+com.graphaware.module.UIDM.uuidRelationshipIndex=relIndex
+com.graphaware.module.UIDM.relationship=com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships
+com.graphaware.module.UIDM.stripHyphens=true
+com.graphaware.module.UIDM.uuidProperty=sequence
+com.graphaware.module.UIDM.uuidGeneratorClass=com.graphaware.module.uuid.generator.SequenceIdGenerator
+
+#*****************************************************************
+# Neo4j configuration
+#*****************************************************************
+
+# The name of the database to mount
+#dbms.active_database=graph.db
+
+# Paths of directories in the installation.
+#dbms.directories.data=data
+#dbms.directories.plugins=plugins
+#dbms.directories.certificates=certificates
+
+# This setting constrains all `LOAD CSV` import files to be under the `import` directory. Remove or uncomment it to
+# allow files to be loaded from anywhere in filesystem; this introduces possible security problems. See the `LOAD CSV`
+# section of the manual for details.
+dbms.directories.import=import
+
+# Whether requests to Neo4j are authenticated.
+# To disable authentication, uncomment this line
+dbms.security.auth_enabled=false
+
+# Enable this to be able to upgrade a store from an older version.
+#dbms.allow_format_migration=true
+
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 50% of RAM minus the max Java heap size.
+#dbms.memory.pagecache.size=10g
+
+# Enable online backups to be taken from this database.
+dbms.backup.enabled=false
+
+# To allow remote backups, uncomment this line:
+#dbms.backup.address=0.0.0.0:6362
+
+#*****************************************************************
+# Network connector configuration
+#*****************************************************************
+
+# Bolt connector
+dbms.connector.bolt.type=BOLT
+dbms.connector.bolt.enabled=true
+dbms.connector.bolt.tls_level=OPTIONAL
+# To have Bolt accept non-local connections, uncomment this line
+# dbms.connector.bolt.address=0.0.0.0:7687
+
+# HTTP Connector
+dbms.connector.http.type=HTTP
+dbms.connector.http.enabled=true
+#dbms.connector.http.encryption=NONE
+# To have HTTP accept non-local connections, uncomment this line
+#dbms.connector.http.address=0.0.0.0:7474
+
+# HTTPS Connector
+dbms.connector.https.type=HTTP
+dbms.connector.https.enabled=true
+dbms.connector.https.encryption=TLS
+dbms.connector.https.address=localhost:7573
+
+# Number of Neo4j worker threads.
+#dbms.threads.worker_count=
+
+#*****************************************************************
+# Logging configuration
+#*****************************************************************
+
+# To enable HTTP logging, uncomment this line
+#dbms.logs.http.enabled=true
+
+# To enable GC Logging, uncomment this line
+#dbms.logs.gc.enabled=true
+
+# GC Logging Options
+# see http://docs.oracle.com/cd/E19957-01/819-0084-10/pt_tuningjava.html#wp57013 for more information.
+#dbms.logs.gc.options=-XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintPromotionFailure -XX:+PrintTenuringDistribution
+
+# Number of GC logs to keep.
+#dbms.logs.gc.rotation.keep_number=5
+
+# Size of each GC log that is kept.
+#dbms.logs.gc.rotation.size=20m
+
+# Size threshold for rotation of the debug log. If set to zero then no rotation will occur. Accepts a binary suffix "k",
+# "m" or "g".
+#dbms.logs.debug.rotation.size=20m
+
+# Maximum number of history files for the internal log.
+#dbms.logs.debug.rotation.keep_number=7
+
+# Log executed queries that takes longer than the configured threshold. Enable by uncommenting this line.
+#dbms.logs.query.enabled=true
+
+# If the execution of query takes more time than this threshold, the query is logged. If set to zero then all queries
+# are logged.
+#dbms.logs.query.threshold=0
+
+# The file size in bytes at which the query log will auto-rotate. If set to zero then no rotation will occur. Accepts a
+# binary suffix "k", "m" or "g".
+#dbms.logs.query.rotation.size=20m
+
+# Maximum number of history files for the query log.
+#dbms.logs.query.rotation.keep_number=7
+
+#*****************************************************************
+# HA configuration
+#*****************************************************************
+
+# Uncomment and specify these lines for running Neo4j in High Availability mode.
+# See the High availability setup tutorial for more details on these settings
+# http://neo4j.com/docs/3.0.1/ha-setup-tutorial.html
+
+# Database mode
+# Allowed values:
+# HA - High Availability
+# SINGLE - Single mode, default.
+# To run in High Availability mode uncomment this line:
+#dbms.mode=HA
+
+# ha.server_id is the number of each instance in the HA cluster. It should be
+# an integer (e.g. 1), and should be unique for each cluster instance.
+#ha.server_id=
+
+# ha.initial_hosts is a comma-separated list (without spaces) of the host:port
+# where the ha.host.coordination of all instances will be listening. Typically
+# this will be the same for all cluster instances.
+#ha.initial_hosts=127.0.0.1:5001,127.0.0.1:5002,127.0.0.1:5003
+
+# IP and port for this instance to listen on, for communicating cluster status
+# information iwth other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.coordination=127.0.0.1:5001
+
+# IP and port for this instance to listen on, for communicating transaction
+# data with other instances (also see ha.initial_hosts). The IP
+# must be the configured IP address for one of the local interfaces.
+#ha.host.data=127.0.0.1:6001
+
+# The interval at which slaves will pull updates from the master. Comment out
+# the option to disable periodic pulling of updates. Unit is seconds.
+ha.pull_interval=10
+
+# Amount of slaves the master will try to push a transaction to upon commit
+# (default is 1). The master will optimistically continue and not fail the
+# transaction even if it fails to reach the push factor. Setting this to 0 will
+# increase write performance when writing through master but could potentially
+# lead to branched data (or loss of transaction) if the master goes down.
+#ha.tx_push_factor=1
+
+# Strategy the master will use when pushing data to slaves (if the push factor
+# is greater than 0). There are three options available "fixed_ascending" (default),
+# "fixed_descending" or "round_robin". Fixed strategies will start by pushing to
+# slaves ordered by server id (accordingly with qualifier) and are useful when
+# planning for a stable fail-over based on ids.
+#ha.tx_push_strategy=fixed_ascending
+
+# Policy for how to handle branched data.
+#ha.branched_data_policy=keep_all
+
+# How often heartbeat messages should be sent. Defaults to ha.default_timeout.
+#ha.heartbeat_interval=5s
+
+# Timeout for heartbeats between cluster members. Should be at least twice that of ha.heartbeat_interval.
+#ha.heartbeat_timeout=11s
+
+# If you are using a load-balancer that doesn't support HTTP Auth, you may need to turn off authentication for the
+# HA HTTP status endpoint by uncommenting the following line.
+#dbms.security.ha_status_auth_enabled=false
+
+# Whether this instance should only participate as slave in cluster. If set to
+# true, it will never be elected as master.
+#ha.slave_only=false
+
+#*****************************************************************
+# Miscellaneous configuration
+#*****************************************************************
+
+# Enable this to specify a parser other than the default one.
+#cypher.default_language_version=3.0
+
+# Determines if Cypher will allow using file URLs when loading data using
+# `LOAD CSV`. Setting this value to `false` will cause Neo4j to fail `LOAD CSV`
+# clauses that load data from the file system.
+#dbms.security.allow_csv_import_from_file_urls=true
+
+# Retention policy for transaction logs needed to perform recovery and backups.
+#dbms.tx_log.rotation.retention_policy=7 days
+
+# Limit the number of IOs the background checkpoint process will consume per second.
+# This setting is advisory, is ignored in Neo4j Community Edition, and is followed to
+# best effort in Enterprise Edition.
+# An IO is in this case a 8 KiB (mostly sequential) write. Limiting the write IO in
+# this way will leave more bandwidth in the IO subsystem to service random-read IOs,
+# which is important for the response time of queries when the database cannot fit
+# entirely in memory. The only drawback of this setting is that longer checkpoint times
+# may lead to slightly longer recovery times in case of a database or system crash.
+# A lower number means lower IO pressure, and consequently longer checkpoint times.
+# The configuration can also be commented out to remove the limitation entirely, and
+# let the checkpointer flush data as fast as the hardware will go.
+# Set this to -1 to disable the IOPS limit.
+# dbms.checkpoint.iops.limit=1000
+
+# Enable a remote shell server which Neo4j Shell clients can log in to.
+#dbms.shell.enabled=true
+# The network interface IP the shell will listen on (use 0.0.0.0 for all interfaces).
+#dbms.shell.host=127.0.0.1
+# The port the shell will listen on, default is 1337.
+#dbms.shell.port=1337
+
+# Only allow read operations from this Neo4j instance. This mode still requires
+# write access to the directory for lock purposes.
+#dbms.read_only=false
+
+# Comma separated list of JAX-RS packages containing JAX-RS resources, one
+# package name for each mountpoint. The listed package names will be loaded
+# under the mountpoints specified. Uncomment this line to mount the
+# org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
+# neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
+# http://localhost:7474/examples/unmanaged/helloworld/{nodeId}
+#dbms.unmanaged_extension_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
+
+


### PR DESCRIPTION
I recently needed to have fine grained control over a generated ID in the Neo4j database and, rather than create the entire module myself, I instead decided to extend/modify the UUID module.

This pull request modifies UUID's configuration, bootstrapper, and module logic to allow the UuidGenerator implementation to be specified through configuration. Two 
UuidGenerator examples are included, one simply making use of the java.util.UUID and another demonstrating the use of the GraphDatabaseService and Cypher to generate a numerically increasing id. The README.md has been updated with configuration examples.

While serving my own needs, this PR also addresses https://github.com/graphaware/neo4j-uuid/issues/21 and facilitates end users for https://github.com/graphaware/neo4j-uuid/issues/16.

Should this PR be accepted and merged, there are two potential long term next steps:

1) Someday it would be nice if the UuidGenerator interface returned Object rather than String, giving implementors more flexibility in what they can return.
2) Given that UuidGenerator implementations may now return values other than a UUID, perhaps this module could/should/would be renamed to something else, such as the GUID module.

Both of the above next steps are probably not worth the time and effort to implement and are instead merely noted for completeness.
