### PR TITLE
Causal Cluster integration: uuid find* procedures in read-mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>uuid</artifactId>
-    <version>3.1.0.44.14-SNAPSHOT</version>
+    <version>3.1.0.45.15-SNAPSHOT</version>
 
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.0.44</version>
+        <version>3.1.1.45-SNAPSHOT</version>
     </parent>
 
     <name>GraphAware UUID Module</name>

--- a/src/main/java/com/graphaware/module/uuid/index/LegacyIndexer.java
+++ b/src/main/java/com/graphaware/module/uuid/index/LegacyIndexer.java
@@ -16,22 +16,40 @@
 
 package com.graphaware.module.uuid.index;
 
-import com.graphaware.module.uuid.UuidConfiguration;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.LegacyIndexHits;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.module.uuid.UuidConfiguration;
 
 /**
  * Legacy Index implementation for indexing and finding nodes and relationships assigned a UUID.
  */
 public class LegacyIndexer implements UuidIndexer {
 
+	private static final Log LOG = LoggerFactory.getLogger(LegacyIndexer.class);
+
+	/**
+	 * Used by relationshipLegacyIndex to skip node-to-node searching (and use only key:value)
+	 */
+	private static final long NO_NODE = -1;
+	
     private final GraphDatabaseService database;
     private final UuidConfiguration configuration;
+	private ThreadToStatementContextBridge statementContext;
 
     public LegacyIndexer(GraphDatabaseService database, UuidConfiguration configuration) {
         this.database = database;
         this.configuration = configuration;
+        GraphDatabaseAPI db = (GraphDatabaseAPI) database;
+        statementContext = db.getDependencyResolver().resolveDependency(ThreadToStatementContextBridge.class);
     }
 
     /**
@@ -47,7 +65,18 @@ public class LegacyIndexer implements UuidIndexer {
      */
     @Override
     public Node getNodeByUuid(String uuid) {
-        return database.index().forNodes(configuration.getUuidIndex()).get(configuration.getUuidProperty(), uuid).getSingle();
+    	// database.index().forNodes is a writing operation, so in a READ_REPLICA and FOLLOWER instances the call fails
+    	ReadOperations readOperations = statementContext.get().readOperations();
+    	try (LegacyIndexHits get = readOperations.nodeLegacyIndexGet(configuration.getUuidIndex(), configuration.getUuidProperty(), uuid);){
+    		if(get.hasNext()){
+    			long idNode = get.next();
+    			return database.getNodeById(idNode);    			
+    		}
+		} catch (LegacyIndexNotFoundKernelException e) {
+			LOG.error("getNodeByUuid("+uuid+"): "+e.getMessage(), e);
+			return null;
+		}
+    	return null;
     }
 
     /**
@@ -78,8 +107,24 @@ public class LegacyIndexer implements UuidIndexer {
      * {@inheritDoc}
      */
     @Override
-    public Relationship getRelationshipByUuid(String uuid) {
-        return database.index().forRelationships(configuration.getUuidRelationshipIndex()).get(configuration.getUuidProperty(), uuid).getSingle();
-    }
+	public Relationship getRelationshipByUuid(String uuid) {
+		// database.index().forNodes is a writing operation, so in a
+		// READ_REPLICA and FOLLOWER instances the call fails
+		ReadOperations readOperations = statementContext.get().readOperations();
+
+		try (LegacyIndexHits get = readOperations.relationshipLegacyIndexGet(configuration.getUuidRelationshipIndex(),
+				configuration.getUuidProperty(), uuid, NO_NODE, NO_NODE);) {
+			
+			if (get.hasNext()) {
+				long idRel = get.next();
+				return database.getRelationshipById(idRel);
+			}
+			
+		} catch (LegacyIndexNotFoundKernelException e) {
+			LOG.error("getNodeByUuid(" + uuid + "): " + e.getMessage(), e);
+			return null;
+		}
+		return null;
+	}
 
 }

--- a/src/main/java/ga/uuid/NodeUuidProcedure.java
+++ b/src/main/java/ga/uuid/NodeUuidProcedure.java
@@ -16,29 +16,28 @@
 
 package ga.uuid;
 
-import com.graphaware.module.uuid.UuidModule;
-import ga.uuid.result.NodeListResult;
-import ga.uuid.result.NodeResult;
-import org.neo4j.graphdb.Node;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.PerformsWrites;
-import org.neo4j.procedure.Procedure;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.Node;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import com.graphaware.module.uuid.UuidModule;
+
+import ga.uuid.result.NodeListResult;
+import ga.uuid.result.NodeResult;
+
 public class NodeUuidProcedure extends UuidProcedure {
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<NodeResult> findNode(@Name("uuid") String uuid) {
         return Stream.of(new NodeResult(findNodeByUuid(UuidModule.DEFAULT_MODULE_ID, uuid)));
     }
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<NodeListResult> findNodes(@Name("uuids") List<String> uuids) {
         List<Node> nodes = uuids.stream().map(uuid -> findNodeByUuid(UuidModule.DEFAULT_MODULE_ID, uuid)).collect(Collectors.toList());
 

--- a/src/main/java/ga/uuid/RelationshipUuidProcedure.java
+++ b/src/main/java/ga/uuid/RelationshipUuidProcedure.java
@@ -16,29 +16,28 @@
 
 package ga.uuid;
 
-import com.graphaware.module.uuid.UuidModule;
-import ga.uuid.result.RelationshipListResult;
-import ga.uuid.result.RelationshipResult;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.PerformsWrites;
-import org.neo4j.procedure.Procedure;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import com.graphaware.module.uuid.UuidModule;
+
+import ga.uuid.result.RelationshipListResult;
+import ga.uuid.result.RelationshipResult;
+
 public class RelationshipUuidProcedure extends UuidProcedure {
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<RelationshipResult> findRelationship(@Name("uuid") String uuid) {
         return Stream.of(new RelationshipResult(findRelationshipByUuid(UuidModule.DEFAULT_MODULE_ID, uuid)));
     }
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<RelationshipListResult> findRelationships(@Name("uuids") List<String> uuids) {
         List<Relationship> relationships = uuids.stream().map(uuid -> findRelationshipByUuid(UuidModule.DEFAULT_MODULE_ID, uuid)).collect(Collectors.toList());
 

--- a/src/main/java/ga/uuid/nd/NodeUuidProcedure.java
+++ b/src/main/java/ga/uuid/nd/NodeUuidProcedure.java
@@ -16,29 +16,27 @@
 
 package ga.uuid.nd;
 
-import ga.uuid.UuidProcedure;
-import ga.uuid.result.NodeListResult;
-import ga.uuid.result.NodeResult;
-import org.neo4j.graphdb.Node;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.PerformsWrites;
-import org.neo4j.procedure.Procedure;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.Node;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import ga.uuid.UuidProcedure;
+import ga.uuid.result.NodeListResult;
+import ga.uuid.result.NodeResult;
+
 public class NodeUuidProcedure extends UuidProcedure {
 
-    @Procedure
-    @PerformsWrites
+	@Procedure(mode = Mode.READ)
     public Stream<NodeResult> findNode(@Name("moduleId") String moduleId, @Name("uuid") String uuid) {
         return Stream.of(new NodeResult(findNodeByUuid(moduleId, uuid)));
     }
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<NodeListResult> findNodes(@Name("moduleId") String moduleId, @Name("uuids") List<String> uuids) {
         List<Node> nodes = uuids.stream().map(uuid -> findNodeByUuid(moduleId, uuid)).collect(Collectors.toList());
 

--- a/src/main/java/ga/uuid/nd/RelationshipUuidProcedure.java
+++ b/src/main/java/ga/uuid/nd/RelationshipUuidProcedure.java
@@ -16,29 +16,27 @@
 
 package ga.uuid.nd;
 
-import ga.uuid.UuidProcedure;
-import ga.uuid.result.RelationshipListResult;
-import ga.uuid.result.RelationshipResult;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.PerformsWrites;
-import org.neo4j.procedure.Procedure;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import ga.uuid.UuidProcedure;
+import ga.uuid.result.RelationshipListResult;
+import ga.uuid.result.RelationshipResult;
+
 public class RelationshipUuidProcedure extends UuidProcedure {
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<RelationshipResult> findRelationship(@Name("moduleId") String moduleId, @Name("uuid") String uuid) {
         return Stream.of(new RelationshipResult(findRelationshipByUuid(moduleId, uuid)));
     }
 
-    @Procedure
-    @PerformsWrites
+    @Procedure(mode = Mode.READ)
     public Stream<RelationshipListResult> findRelationships(@Name("moduleId") String moduleId, @Name("uuids") List<String> uuids) {
         List<Relationship> relationships = uuids.stream().map(uuid -> findRelationshipByUuid(moduleId, uuid)).collect(Collectors.toList());
 

--- a/src/test/java/ga/uuid/UuidProcedureTestCausalCluster.java
+++ b/src/test/java/ga/uuid/UuidProcedureTestCausalCluster.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package ga.uuid;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.proc.Procedures;
+
+import com.graphaware.common.policy.BaseNodeInclusionPolicy;
+import com.graphaware.common.policy.BaseRelationshipInclusionPolicy;
+import com.graphaware.module.uuid.UuidConfiguration;
+import com.graphaware.module.uuid.UuidModule;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.runtime.module.RuntimeModule;
+import com.graphaware.test.integration.cluster.CausalClusterDatabasesintegrationTest;
+
+/**
+ * Test for {@link NodeUuidProcedure} and {@link RelationshipUuidProcedure}
+ */
+public class UuidProcedureTestCausalCluster extends CausalClusterDatabasesintegrationTest {
+
+	private static UuidConfiguration uuidConfiguration;
+	private static String aleUuid;
+	private static Long aleId;
+	private static Long idRel;
+	private static String relUuid;
+
+	private static void registerRuntimeWithModule(GraphDatabaseService database, RuntimeModule module) {
+		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
+		runtime.registerModule(module);
+		runtime.start();
+	}
+
+	private static void registerModule(GraphDatabaseService database) {
+		uuidConfiguration = UuidConfiguration.defaultConfiguration().withUuidProperty("uuid").withUuidIndex("uuidIndex")
+				.with(new BaseNodeInclusionPolicy() {
+					@Override
+					public boolean include(Node node) {
+						return true;
+					}
+				}).with(new BaseRelationshipInclusionPolicy() {
+
+					@Override
+					public boolean include(Relationship relationship) {
+						return true;
+					}
+
+					@Override
+					public boolean include(Relationship relationship, Node node) {
+						return true;
+					}
+				});
+
+		UuidModule module = new UuidModule(UuidModule.DEFAULT_MODULE_ID, uuidConfiguration, database);
+		registerRuntimeWithModule(database, module);
+	}
+
+	@Override
+	protected boolean shouldRegisterProcedures() {
+		return true;
+	}
+	
+	@Override
+	protected void registerProcedures(Procedures procedures) throws Exception {
+		super.registerProcedures(procedures);
+		procedures.registerProcedure(NodeUuidProcedure.class);
+		procedures.registerProcedure(RelationshipUuidProcedure.class);
+	}
+	
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		if(uuidConfiguration == null){
+			GraphDatabaseService leaderDatabase = getLeaderDatabase();
+			
+			registerModule(leaderDatabase);
+			getFollowers().forEach(db -> registerModule(db));			
+			getReplicas().forEach(db -> registerModule(db));	
+			
+			aleId = createPerson(leaderDatabase,"Alessandro");
+			aleUuid = getUuidForNode(leaderDatabase,aleId);
+
+			createPerson(leaderDatabase,"Raffaello");
+			idRel = createRelation(leaderDatabase, "Alessandro","Raffaello");
+			relUuid = getUuidForRelation(leaderDatabase, idRel);
+			
+	    	GraphDatabaseService replDb = getOneReplicaDatabase();
+	    	
+	    	//waiting for replica synchronization
+	        try (Transaction tx = replDb.beginTx()) {
+	        	do{
+	        		Thread.currentThread().sleep(1000L);
+	        	} while (! (replDb.index().existsForNodes(UuidConfiguration.defaultConfiguration().getUuidIndex())
+	        			&& replDb.index().existsForRelationships(UuidConfiguration.defaultConfiguration().getUuidRelationshipIndex())));
+	        	
+	            tx.failure();
+	        }
+		}
+	}
+	
+    
+
+	@Test
+    public void testGetNodeByUuid_LEADER() {
+    	GraphDatabaseService database = getLeaderDatabase();
+		testCallNode(database);
+    }
+
+    @Test
+    public void testGetNodeByUuid_FOLLOWER() {
+    	GraphDatabaseService database = getOneFollowerDatabase();
+		testCallNode(database);
+    }
+    
+    @Test
+    public void testGetNodeByUuid_REPLICA() throws InterruptedException {
+    	GraphDatabaseService replDb = getOneReplicaDatabase();
+		testCallNode(replDb);
+    }
+    
+	@Test
+    public void testGetRelationByUuid_LEADER() {
+    	GraphDatabaseService database = getLeaderDatabase();
+		testCallRel(database);
+    }
+
+    @Test
+    public void testGetRelationByUuid_FOLLOWER() {
+    	GraphDatabaseService database = getOneFollowerDatabase();
+		testCallRel(database);
+    }
+    
+    @Test
+    public void testGetRelationByUuid_REPLICA() throws InterruptedException {
+    	GraphDatabaseService replDb = getOneReplicaDatabase();
+		testCallRel(replDb);
+    }
+
+	private void testCallRel(GraphDatabaseService database) {
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.uuid.findRelationship('" + relUuid + "') YIELD relationship RETURN relationship as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Relationship rel = (Relationship) row.get("n");
+                assertEquals(idRel, rel.getId(), 0L);
+            }
+
+            tx.success();
+        }
+	}
+    
+	private void testCallNode(GraphDatabaseService database) {
+        try (Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL ga.uuid.findNode('" + aleUuid + "') YIELD node RETURN node as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Node node = (Node) row.get("n");
+                assertEquals(aleId, node.getId(), 0L);
+            }
+
+            tx.success();
+        }
+	}
+    
+    private String getUuidForNode(GraphDatabaseService db, Long id) {
+        String uuid = null;
+        try (Transaction tx = db.beginTx()) {
+            uuid = db.getNodeById(id).getProperty("uuid").toString();
+            tx.success();
+        }
+
+        return uuid;
+    }
+
+    private String getUuidForRelation(GraphDatabaseService db, Long id) {
+        String uuid = null;
+        try (Transaction tx = db.beginTx()) {
+            uuid = db.getRelationshipById(id).getProperty("uuid").toString();
+            tx.success();
+        }
+
+        return uuid;
+    }
+    
+    private Long createPerson(GraphDatabaseService db, String name) {
+        Long id = null;
+        Map<String, Object> props = new HashMap<>();
+        props.put("name", name);
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("CREATE (n:Person {name: {name} }) RETURN id(n) as id", props);
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                id = (long) row.get("id");
+            }
+
+            tx.success();
+        }
+
+        return id;
+    }
+    
+    private Long createRelation(GraphDatabaseService db, String nameFrom, String nameTo) {
+        Long id = null;
+        Map<String, Object> props = new HashMap<>();
+        props.put("nameFrom", nameFrom);
+        props.put("nameTo", nameTo);
+        
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("MATCH (a:Person {name: {nameFrom} }),(b:Person {name: {nameTo} }) \n CREATE (a)-[r:LIKES]->(b) RETURN id(r) as id", props);
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                id = (long) row.get("id");
+            }
+
+            tx.success();
+        }
+
+        return id;
+	}
+}

--- a/src/test/java/ga/uuid/UuidProcedureTestHighAvailability.java
+++ b/src/test/java/ga/uuid/UuidProcedureTestHighAvailability.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -43,18 +42,14 @@ import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesI
  */
 public class UuidProcedureTestHighAvailability extends HighAvailabilityClusterDatabasesIntegrationTest {
 
-	// private final RelationshipType knowsType =
-	// RelationshipType.withName("KNOWS");
-	private static UuidConfiguration uuidConfiguration;
-
-	private static void registerRuntimeWithModule(GraphDatabaseService database, RuntimeModule module) {
+	private void registerRuntimeWithModule(GraphDatabaseService database, RuntimeModule module) {
 		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
 		runtime.registerModule(module);
 		runtime.start();
 	}
 
-	private static void registerModule(GraphDatabaseService database) {
-		uuidConfiguration = UuidConfiguration.defaultConfiguration().withUuidProperty("uuid").withUuidIndex("uuidIndex")
+	protected void registerModule(GraphDatabaseService database) {
+		UuidConfiguration uuidConfiguration = UuidConfiguration.defaultConfiguration().withUuidProperty("uuid").withUuidIndex("uuidIndex")
 				.with(new BaseNodeInclusionPolicy() {
 					@Override
 					public boolean include(Node node) {
@@ -78,6 +73,11 @@ public class UuidProcedureTestHighAvailability extends HighAvailabilityClusterDa
 	}
 
 	@Override
+	protected boolean shouldRegisterModules() {
+		return true;
+	}
+	
+	@Override
 	protected boolean shouldRegisterProcedures() {
 		return true;
 	}
@@ -87,16 +87,6 @@ public class UuidProcedureTestHighAvailability extends HighAvailabilityClusterDa
 		super.registerProcedures(procedures);
 		procedures.registerProcedure(NodeUuidProcedure.class);
 		procedures.registerProcedure(RelationshipUuidProcedure.class);
-	}
-	
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-		if(uuidConfiguration == null){
-			registerModule(getMainDatabase());
-			getSlaveDatabases().forEach(db -> registerModule(db));			
-		}
 	}
 
     @Test

--- a/src/test/java/ga/uuid/UuidProcedureTestHighAvailability.java
+++ b/src/test/java/ga/uuid/UuidProcedureTestHighAvailability.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package ga.uuid;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.proc.Procedures;
+
+import com.graphaware.common.policy.BaseNodeInclusionPolicy;
+import com.graphaware.common.policy.BaseRelationshipInclusionPolicy;
+import com.graphaware.module.uuid.UuidConfiguration;
+import com.graphaware.module.uuid.UuidModule;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.runtime.module.RuntimeModule;
+import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesIntegrationTest;
+
+/**
+ * Test for {@link NodeUuidProcedure} and {@link RelationshipUuidProcedure}
+ */
+public class UuidProcedureTestHighAvailability extends HighAvailabilityClusterDatabasesIntegrationTest {
+
+	// private final RelationshipType knowsType =
+	// RelationshipType.withName("KNOWS");
+	private static UuidConfiguration uuidConfiguration;
+
+	private static void registerRuntimeWithModule(GraphDatabaseService database, RuntimeModule module) {
+		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
+		runtime.registerModule(module);
+		runtime.start();
+	}
+
+	private static void registerModule(GraphDatabaseService database) {
+		uuidConfiguration = UuidConfiguration.defaultConfiguration().withUuidProperty("uuid").withUuidIndex("uuidIndex")
+				.with(new BaseNodeInclusionPolicy() {
+					@Override
+					public boolean include(Node node) {
+						return true;
+					}
+				}).with(new BaseRelationshipInclusionPolicy() {
+
+					@Override
+					public boolean include(Relationship relationship) {
+						return true;
+					}
+
+					@Override
+					public boolean include(Relationship relationship, Node node) {
+						return true;
+					}
+				});
+
+		UuidModule module = new UuidModule(UuidModule.DEFAULT_MODULE_ID, uuidConfiguration, database);
+		registerRuntimeWithModule(database, module);
+	}
+
+	@Override
+	protected boolean shouldRegisterProcedures() {
+		return true;
+	}
+	
+	@Override
+	protected void registerProcedures(Procedures procedures) throws Exception {
+		super.registerProcedures(procedures);
+		procedures.registerProcedure(NodeUuidProcedure.class);
+		procedures.registerProcedure(RelationshipUuidProcedure.class);
+	}
+	
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		if(uuidConfiguration == null){
+			registerModule(getMainDatabase());
+			getSlaveDatabases().forEach(db -> registerModule(db));			
+		}
+	}
+
+    @Test
+    public void testGetRelationshipByUuid_MASTER() {
+        GraphDatabaseService db = getMasterDatabase();
+		createPerson(db,"AlessandroMaster1");
+        createPerson(db,"AlessandroMaster2");
+        Long idRel = createRelation(db, "AlessandroMaster1", "AlessandroMaster2");
+        String relUuid = getUuidForRelation(db, idRel);
+        
+        try (Transaction tx = db.beginTx()) {
+        	Result result = db.execute("CALL ga.uuid.findRelationship('" + relUuid + "') YIELD relationship RETURN relationship as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Relationship rel = (Relationship) row.get("n");
+                assertEquals(idRel, rel.getId(), 0L);
+            }
+
+            tx.success();
+        }
+    }
+    
+    @Test
+    public void testGetRelationshipByUuid_SLAVE() {
+        GraphDatabaseService db = getMasterDatabase();
+		createPerson(db,"AlessandroSlave1");
+        createPerson(db,"AlessandroSlave2");
+        Long idRel = createRelation(db, "AlessandroSlave1", "AlessandroSlave2");
+        String relUuid = getUuidForRelation(db, idRel);
+        
+        try (Transaction tx = db.beginTx()) {
+        	Result result = db.execute("CALL ga.uuid.findRelationship('" + relUuid + "') YIELD relationship RETURN relationship as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Relationship rel = (Relationship) row.get("n");
+                assertEquals(idRel, rel.getId(), 0L);
+            }
+
+            tx.success();
+        }
+    }
+	
+    @Test
+    public void testGetNodeByUuid_MASTER() {
+        Long aleId = createPerson(getMasterDatabase(),"AlessandroMaster");
+        String aleUuid = getUuidForNode(getMasterDatabase(),aleId);
+        try (Transaction tx = getMasterDatabase().beginTx()) {
+            Result result = getMasterDatabase().execute("CALL ga.uuid.findNode('" + aleUuid + "') YIELD node RETURN node as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Node node = (Node) row.get("n");
+                assertEquals(aleId, node.getId(), 0L);
+            }
+
+            tx.success();
+        }
+    }
+
+    @Test
+    public void testGetNodeByUuid_SLAVE() {
+        Long aleId = createPerson(getOneSlaveDatabase(),"AlessandroSlave");
+        String aleUuid = getUuidForNode(getOneSlaveDatabase(),aleId);
+        try (Transaction tx = getOneSlaveDatabase().beginTx()) {
+            Result result = getOneSlaveDatabase().execute("CALL ga.uuid.findNode('" + aleUuid + "') YIELD node RETURN node as n");
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                Node node = (Node) row.get("n");
+                assertEquals(aleId, node.getId(), 0L);
+            }
+
+            tx.success();
+        }
+    }
+    
+    private String getUuidForNode(GraphDatabaseService db, Long id) {
+        String uuid = null;
+        try (Transaction tx = db.beginTx()) {
+            uuid = db.getNodeById(id).getProperty("uuid").toString();
+            tx.success();
+        }
+
+        return uuid;
+    }
+
+    private Long createPerson(GraphDatabaseService db, String name) {
+        Long id = null;
+        Map<String, Object> props = new HashMap<>();
+        props.put("name", name);
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("CREATE (n:Person {name: {name} }) RETURN id(n) as id", props);
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                id = (long) row.get("id");
+            }
+
+            tx.success();
+        }
+
+        return id;
+    }
+    
+    private Long createRelation(GraphDatabaseService db, String nameFrom, String nameTo) {
+        Long id = null;
+        Map<String, Object> props = new HashMap<>();
+        props.put("nameFrom", nameFrom);
+        props.put("nameTo", nameTo);
+        
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("MATCH (a:Person {name: {nameFrom} }),(b:Person {name: {nameTo} }) \n CREATE (a)-[r:LIKES]->(b) RETURN id(r) as id", props);
+            while (result.hasNext()) {
+                Map<String, Object> row = result.next();
+                id = (long) row.get("id");
+            }
+
+            tx.success();
+        }
+
+        return id;
+	}
+    
+
+    private String getUuidForRelation(GraphDatabaseService db, Long id) {
+        String uuid = null;
+        try (Transaction tx = db.beginTx()) {
+            uuid = db.getRelationshipById(id).getProperty("uuid").toString();
+            tx.success();
+        }
+
+        return uuid;
+    }
+}


### PR DESCRIPTION
The findNode and findRelationship procedures didn't work on FOLLOWER and REPLICA because they used a DataWriteOperation (see LegacyIndexer). Now, using kernel API, they are in read-only mode, so they can be used in all the instances of the cluster.

PROPOSAL:  convert the procedures into user-defined-function